### PR TITLE
feat: add Nix Flake support and installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,41 @@ sudo bash install.sh
 curl https://raw.githubusercontent.com/mdminhazulhaque/probhat-osx/master/install.sh | sudo bash
 ```
 
+### Method 3: Nix Flake
+
+#### Option A — Install directly to your Nix profile
+
+```bash
+nix profile install github:mdminhazulhaque/probhat-macos
+sudo cp ~/.nix-profile/Library/Keyboard\ Layouts/Probhat.* /Library/Keyboard\ Layouts/
+```
+
+#### Option B — nix-darwin module
+
+Add the flake as an input and enable the module in your `darwin-configuration.nix`:
+
+```nix
+{
+  inputs.probhat-macos = {
+    url = "github:mdminhazulhaque/probhat-macos";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, darwin, nixpkgs, probhat-macos, ... }: {
+    darwinConfigurations."my-mac" = darwin.lib.darwinSystem {
+      modules = [
+        probhat-macos.darwinModules.default
+        {
+          programs.probhat.enable = true;
+        }
+      ];
+    };
+  };
+}
+```
+
+Then apply with `darwin-rebuild switch`.
+
 ---
 
 Enter your password when prompted. The installer will copy the necessary files to `/Library/Keyboard\ Layouts` directory.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,61 +1,69 @@
 {
   description = "Probhat Bengali keyboard layout for macOS";
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  };
+
   outputs = { self, nixpkgs }:
     let
-      systems = [ "aarch64-darwin" "x86_64-darwin" ];
-      mkProbhat = pkgs: pkgs.stdenvNoCC.mkDerivation {
-        pname = "probhat-keylayout";
-        version = "1.0.0";
-        src = ./.;
-        dontBuild = true;
-        installPhase = ''
-          mkdir -p "$out/Library/Keyboard Layouts"
-          cp Probhat.keylayout Probhat.icns "$out/Library/Keyboard Layouts/"
-        '';
-        meta = {
-          description = "Probhat fixed-layout Bengali keyboard for macOS";
-          homepage = "https://github.com/mdminhazulhaque/probhat-macos";
-          license = nixpkgs.lib.licenses.mit;
-          platforms = nixpkgs.lib.platforms.darwin;
-        };
-      };
+      supportedSystems = [ "aarch64-darwin" "x86_64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
     in
     {
-      packages = nixpkgs.lib.genAttrs systems (system:
-        let pkg = mkProbhat nixpkgs.legacyPackages.${system};
-        in { probhat = pkg; default = pkg; });
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          probhat = pkgs.stdenvNoCC.mkDerivation {
+            pname = "probhat-keylayout";
+            version = "1.0.0";
+            src = ./.;
 
-      # Usage in nix-darwin:
-      #   inputs.probhat-macos.url = "github:audacioustux/probhat-macos";
-      #   imports = [ probhat-macos.darwinModules.default ];
-      #   programs.probhat.enable = true;
+            dontBuild = true;
+
+            installPhase = ''
+              mkdir -p "$out/Library/Keyboard Layouts"
+              cp Probhat.keylayout Probhat.icns "$out/Library/Keyboard Layouts/"
+            '';
+
+            meta = {
+              description = "Probhat fixed-layout Bengali keyboard for macOS";
+              homepage = "https://github.com/audacioustux/probhat-macos";
+              license = nixpkgs.lib.licenses.mit;
+              platforms = nixpkgs.lib.platforms.darwin;
+            };
+          };
+          default = self.packages.${system}.probhat;
+        });
+
+      formatter = forAllSystems (system: nixpkgs.legacyPackages.${system}.nixpkgs-fmt);
+
       darwinModules.default = { config, lib, pkgs, ... }:
         let
+          cfg = config.programs.probhat;
           dst = "/Library/Keyboard Layouts";
-          pkg = mkProbhat pkgs;
+          pkg = self.packages.${pkgs.system}.default;
           src = "${pkg}/Library/Keyboard Layouts";
-        in {
+        in
+        {
           options.programs.probhat.enable =
             lib.mkEnableOption "Probhat Bengali keyboard layout";
 
-          config = lib.mkMerge [
-            (lib.mkIf config.programs.probhat.enable {
-              system.activationScripts.postActivation.text = ''
+          config = lib.mkIf (pkgs.stdenv.isDarwin) {
+            system.activationScripts.postActivation.text =
+              if cfg.enable then ''
                 echo "Installing Probhat keyboard layout..." >&2
                 mkdir -p "${dst}"
                 install -m 644 "${src}/Probhat.keylayout" "${dst}/Probhat.keylayout"
                 install -m 644 "${src}/Probhat.icns" "${dst}/Probhat.icns"
-              '';
-            })
-            (lib.mkIf (!config.programs.probhat.enable) {
-              system.activationScripts.postActivation.text = ''
+              '' else ''
                 echo "Removing Probhat keyboard layout..." >&2
                 rm -f "${dst}/Probhat.keylayout"
                 rm -f "${dst}/Probhat.icns"
               '';
-            })
-          ];
+          };
         };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "Probhat Bengali keyboard layout for macOS";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "aarch64-darwin" "x86_64-darwin" ];
+
+      mkProbhat = pkgs: pkgs.stdenvNoCC.mkDerivation {
+        pname = "probhat-keylayout";
+        version = "1.0.0";
+        src = ./.;
+        dontBuild = true;
+        installPhase = ''
+          mkdir -p "$out/Library/Keyboard Layouts"
+          cp Probhat.keylayout Probhat.icns "$out/Library/Keyboard Layouts/"
+        '';
+        meta = {
+          description = "Probhat fixed-layout Bengali keyboard for macOS";
+          homepage = "https://github.com/mdminhazulhaque/probhat-macos";
+          license = nixpkgs.lib.licenses.mit;
+          platforms = nixpkgs.lib.platforms.darwin;
+        };
+      };
+    in
+    {
+      packages = nixpkgs.lib.genAttrs systems (system:
+        let pkg = mkProbhat nixpkgs.legacyPackages.${system};
+        in { probhat = pkg; default = pkg; });
+
+      # Usage in nix-darwin:
+      #   imports = [ probhat-macos.darwinModules.default ];
+      #   programs.probhat.enable = true;
+      darwinModules.default = { config, lib, pkgs, ... }: {
+        options.programs.probhat.enable =
+          lib.mkEnableOption "Probhat Bengali keyboard layout";
+
+        config = lib.mkIf config.programs.probhat.enable {
+          system.activationScripts.probhat.text =
+            let
+              pkg = mkProbhat pkgs;
+              src = "${pkg}/Library/Keyboard Layouts";
+              dst = "/Library/Keyboard Layouts";
+            in ''
+              install -m 644 "${src}/Probhat.keylayout" "${src}/Probhat.icns" "${dst}/"
+            '';
+        };
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Probhat Bengali keyboard layout for macOS";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-stable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
   outputs = { self, nixpkgs }:
     let

--- a/flake.nix
+++ b/flake.nix
@@ -35,20 +35,27 @@
           dst = "/Library/Keyboard Layouts";
           pkg = mkProbhat pkgs;
           src = "${pkg}/Library/Keyboard Layouts";
-          files = [ "Probhat.keylayout" "Probhat.icns" ];
         in {
           options.programs.probhat.enable =
             lib.mkEnableOption "Probhat Bengali keyboard layout";
 
-          config.system.activationScripts.probhat.text =
-            if config.programs.probhat.enable then ''
-              echo "Installing Probhat keyboard layout..." >&2
-              install -m 644 "${src}/Probhat.keylayout" "${src}/Probhat.icns" "${dst}/"
-            ''
-            else ''
-              echo "Removing Probhat keyboard layout..." >&2
-              ${lib.concatMapStringsSep "\n" (f: "rm -f '${dst}/${f}'") files}
-            '';
+          config = lib.mkMerge [
+            (lib.mkIf config.programs.probhat.enable {
+              system.activationScripts.postActivation.text = ''
+                echo "Installing Probhat keyboard layout..." >&2
+                mkdir -p "${dst}"
+                install -m 644 "${src}/Probhat.keylayout" "${dst}/Probhat.keylayout"
+                install -m 644 "${src}/Probhat.icns" "${dst}/Probhat.icns"
+              '';
+            })
+            (lib.mkIf (!config.programs.probhat.enable) {
+              system.activationScripts.postActivation.text = ''
+                echo "Removing Probhat keyboard layout..." >&2
+                rm -f "${dst}/Probhat.keylayout"
+                rm -f "${dst}/Probhat.icns"
+              '';
+            })
+          ];
         };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Probhat Bengali keyboard layout for macOS";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-stable";
 
   outputs = { self, nixpkgs }:
     let


### PR DESCRIPTION
Adds a Method 3 section to the Installation instructions documenting how to install Probhat using the existing `flake.nix`:

- **Option A**: `nix profile install` for a quick ad-hoc install
- **Option B**: nix-darwin module integration with `programs.probhat.enable = true`